### PR TITLE
fix 404 page

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -136,7 +136,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
-  createResponsivePictures(main);
+  !window.isErrorPage && createResponsivePictures(main);
 }
 
 /**


### PR DESCRIPTION
This fixes the error that was preventing the 404 page from working.

Test URLs:
- Before: [Climbing New Zealand - 404 page](https://main--demo-wknd--erhanabi.hlx.page/adventures/climbing-new-zealand)
- After: [Climbing New Zealand - 404 page](https://fix_404--demo-wknd--erhanabi.hlx.page/adventures/climbing-new-zealand)
